### PR TITLE
fix bug event path

### DIFF
--- a/client/assets/localScripts/MiniMap.js
+++ b/client/assets/localScripts/MiniMap.js
@@ -49,7 +49,6 @@ module.exports = class MiniMap {
     const localCtx = arguments[1];
     const gameView = localCtx.getGameView();
     const userID = gameView.getUserData('userID');
-    console.log('init mini map');
 
     const manager = gameView.getInputManager();
     const Command = udviz.Game.Command;

--- a/client/assets/localScripts/MiniMap.js
+++ b/client/assets/localScripts/MiniMap.js
@@ -49,6 +49,7 @@ module.exports = class MiniMap {
     const localCtx = arguments[1];
     const gameView = localCtx.getGameView();
     const userID = gameView.getUserData('userID');
+    console.log('init mini map');
 
     const manager = gameView.getInputManager();
     const Command = udviz.Game.Command;
@@ -79,12 +80,12 @@ module.exports = class MiniMap {
 
     manager.addMouseCommand('click', function () {
       const event = this.event('click');
-      const id = event.path.indexOf(ui);
-      if (id < 0) return null;
+
+      if (event.target != ui) return null;
       const x = event.pageX;
       const y = event.pageY;
 
-      const rect = event.path[id].getBoundingClientRect();
+      const rect = event.target.getBoundingClientRect();
       const ratioX = (x - rect.left) / (rect.right - rect.left);
       const ratioY = 1 - (y - rect.top) / (rect.bottom - rect.top);
 


### PR DESCRIPTION
The path property of Event objects is non-standard. (:x: Firefox)
Then we prefer use event.target (we don't need path actually)

[event](https://stackoverflow.com/questions/39245488/event-path-is-undefined-running-in-firefox)